### PR TITLE
Replace … with QChar(code 0x2026) to fix error C2001 and C2143 when building with msvc2019

### DIFF
--- a/src/ImageViewer/src/GUI/Dialogs/InfoDialog.cpp
+++ b/src/ImageViewer/src/GUI/Dialogs/InfoDialog.cpp
@@ -55,7 +55,7 @@ QString formatMetaDataEntryValue(const QString &value)
 {
     if(value.length() <= MAX_METADATA_ENTRY_VALUE_LENGTH)
         return value;
-    return value.left(MAX_METADATA_ENTRY_VALUE_LENGTH).append(QString::fromUtf8("…"));
+    return value.left(MAX_METADATA_ENTRY_VALUE_LENGTH).append(QChar(0x2026));
 }
 
 QDateTime getCreatedTime(const QFileInfo &fileInfo)


### PR DESCRIPTION
It should be caused by the current Code Page(当前代码页) which is not compatible with encoding(utf-8) of the source file.
![2024-06-19_234121](https://github.com/AlienCowEatCake/ImageViewer/assets/46510529/da86f565-d80e-4e02-b1a7-dfb634758994)
Alternatively, specifying Code Page for msvc toolchain at compile time may be another way to fix the issue.
